### PR TITLE
examples can show up on the pub site

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,13 @@
+import 'package:http_multi_server/http_multi_server.dart';
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf_io.dart' as shelf_io;
+
+void main() {
+  // Both http://127.0.0.1:8080 and http://[::1]:8080 will be bound to the same
+  // server.
+  HttpMultiServer.loopback(8080).then((server) {
+    shelf_io.serveRequests(server, (request) {
+      return new shelf.Response.ok("Hello, world!");
+    });
+  });
+}


### PR DESCRIPTION
The pub site can show example code for a package.
https://www.dartlang.org/tools/pub/package-layout#examples

related issue : dart-lang/site-www#413