### PR TITLE
Close Ipv4 server when failing to start Ipv6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.6
+
+* If there is a problem starting a loopback Ipv6 server, don't keep the Ipv4
+  server open when throwing the exception.
+
 ## 2.0.5
 
 * Update SDK constraints to `>=2.0.0-dev <3.0.0`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_multi_server
-version: 2.0.6-dev
+version: 2.0.6
 
 description: A dart:io HttpServer wrapper that handles requests from multiple servers.
 author: Dart Team <misc@dartlang.org>


### PR DESCRIPTION
Fixes a bug that could prevent the VM from shutting down if there is a
port conflict with Ipv6 but not Ipv4.