### PR TITLE
Update packages with HttpHeaders' preserveHeaderCase change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.2.0
+
+* Preparation for [HttpHeaders change].
+  Update signature of `MultiHeaders.add()` and `MultiHeaders.set()` to match
+  new signature of `HttpHeaders`.
+  Bump the SDK constraints to `>=2.8.0.dev.20.0` temporarily until the change
+  in SDK has rolled into a stable release.
+
+  [HttpHeaders change]: https://github.com/dart-lang/sdk/issues/39657
+
 ## 2.1.0
 
 - Add `HttpMultiServer.bind` static which centralizes logic around common local

--- a/lib/src/multi_headers.dart
+++ b/lib/src/multi_headers.dart
@@ -94,9 +94,9 @@ class MultiHeaders implements HttpHeaders {
   MultiHeaders(Iterable<HttpHeaders> headers) : _headers = headers.toSet();
 
   @override
-  void add(String name, Object value) {
+  void add(String name, Object value, {bool preserveHeaderCase = false}) {
     for (var headers in _headers) {
-      headers.add(name, value);
+      headers.add(name, value, preserveHeaderCase: preserveHeaderCase);
     }
   }
 
@@ -126,9 +126,9 @@ class MultiHeaders implements HttpHeaders {
   }
 
   @override
-  void set(String name, Object value) {
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
     for (var headers in _headers) {
-      headers.set(name, value);
+      headers.set(name, value, preserveHeaderCase: preserveHeaderCase);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_multi_server
-version: 2.1.1-dev
+version: 2.2.0-dev
 
 description: >-
   A dart:io HttpServer wrapper that handles requests from multiple servers.
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/http_multi_server
 
 environment:
-  sdk: '>=2.1.1 <3.0.0'
+  sdk: '>=2.8.0.dev.20.0 <3.0.0'
 
 dependencies:
   async: '>=1.2.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/http_multi_server
 
 environment:
-  sdk: '>=2.8.0.dev.20.0 <3.0.0'
+  sdk: '>=2.8.0-dev.20.0 <3.0.0'
 
 dependencies:
   async: '>=1.2.0 <3.0.0'


### PR DESCRIPTION
Prepare for [breaking change](https://github.com/dart-lang/sdk/issues/39657).

The SDK constraint is bumped up temporarily until the main change is rolled into a stable release.