### PR TITLE
Add preserveHeaderCase argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.2.0-dev
+
+- Preparation for [HttpHeaders change]. Update signature of `MultiHeaders.add()`
+  and `MultiHeaders.set()` to match new signature of `HttpHeaders`. The
+  parameter is not yet forwarded and will not behave as expected.
+
+  [HttpHeaders change]: https://github.com/dart-lang/sdk/issues/39657
+
 ## 2.1.0
 
 - Add `HttpMultiServer.bind` static which centralizes logic around common local

--- a/lib/src/multi_headers.dart
+++ b/lib/src/multi_headers.dart
@@ -94,7 +94,7 @@ class MultiHeaders implements HttpHeaders {
   MultiHeaders(Iterable<HttpHeaders> headers) : _headers = headers.toSet();
 
   @override
-  void add(String name, Object value) {
+  void add(String name, Object value, {bool preserveHeaderCase = false}) {
     for (var headers in _headers) {
       headers.add(name, value);
     }
@@ -126,7 +126,7 @@ class MultiHeaders implements HttpHeaders {
   }
 
   @override
-  void set(String name, Object value) {
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {
     for (var headers in _headers) {
       headers.set(name, value);
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,6 @@
 name: http_multi_server
 version: 2.2.0-dev
+publish_to: none # https://github.com/dart-lang/http_multi_server/issues/23
 
 description: >-
   A dart:io HttpServer wrapper that handles requests from multiple servers.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_multi_server
-version: 2.1.1-dev
+version: 2.2.0-dev
 
 description: >-
   A dart:io HttpServer wrapper that handles requests from multiple servers.


### PR DESCRIPTION
An upcoming SDK release will add a named argument which must be included
for any class which `implements` the interface. Pre-emptively add the
argument to the signature so that we have a version of this package
which is forward compatible with the SDK. We will properly forward the
argument once we have an SDK release with the change.