### PR TITLE
Remove unused dart:async import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 2.2.1-dev
+
 ## 2.2.0
 
 - Preparation for [HttpHeaders change]. Update signature of `MultiHeaders.add()`

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 /// Returns whether this computer supports binding to IPv6 addresses.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_multi_server
-version: 2.2.0
+version: 2.2.1-dev
 
 description: >-
   A dart:io HttpServer wrapper that handles requests from multiple servers.


### PR DESCRIPTION
Since Dart 2.1, Future/Stream have been exported from dart:core