### PR TITLE
Skip test binding to IPv4 without support

### DIFF
--- a/test/http_multi_server_test.dart
+++ b/test/http_multi_server_test.dart
@@ -220,16 +220,15 @@ void main() {
     });
 
     test('listens on specified hostname', () async {
+      if (!await supportsIPv4) return;
       final server = await HttpMultiServer.bind(InternetAddress.anyIPv4, 0);
       server.listen((request) {
         request.response.write('got request');
         request.response.close();
       });
 
-      if (await supportsIPv4) {
-        expect(http.read(Uri.http('127.0.0.1:${server.port}', '/')),
-            completion(equals('got request')));
-      }
+      expect(http.read(Uri.http('127.0.0.1:${server.port}', '/')),
+          completion(equals('got request')));
 
       if (await supportsIPv6) {
         expect(http.read(Uri.http('[::1]:${server.port}', '/')),


### PR DESCRIPTION
Bail out of a test early if the host does not support IPv4. This cannot
use the `skip` mechanism since the condition is async.