### PR TITLE
Forward the preserveHeaderCase argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## 3.1.1-dev
+## 3.2.0
+
+* Honor the `preserveHeaderCase` argument to `MultiHeaders.set` and `.add`.
 
 ## 3.1.0
 

--- a/lib/src/multi_headers.dart
+++ b/lib/src/multi_headers.dart
@@ -96,7 +96,7 @@ class MultiHeaders implements HttpHeaders {
   @override
   void add(String name, Object value, {bool preserveHeaderCase = false}) {
     for (var headers in _headers) {
-      headers.add(name, value);
+      headers.add(name, value, preserveHeaderCase: preserveHeaderCase);
     }
   }
 
@@ -128,7 +128,7 @@ class MultiHeaders implements HttpHeaders {
   @override
   void set(String name, Object value, {bool preserveHeaderCase = false}) {
     for (var headers in _headers) {
-      headers.set(name, value);
+      headers.set(name, value, preserveHeaderCase: preserveHeaderCase);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: http_multi_server
-version: 3.1.1-dev
+version: 3.2.0
 
 description: >-
   A dart:io HttpServer wrapper that handles requests from multiple servers.


### PR DESCRIPTION
Closes dart-lang/http#1427

The min SDK constraint is already higher than 2.8 which is the version
which introduced this argument.