### PR TITLE
Drop unnecessary SDK constraint suffix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,7 +6,7 @@ description: >-
 homepage: https://github.com/dart-lang/http_multi_server
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   async: ^2.5.0


### PR DESCRIPTION
The `-0` suffix allowed pre-stable SDKs before the launch of null
safety, but with the stable release available it is not necessary.